### PR TITLE
added test for vite

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,10 +116,6 @@ importers:
         version: 0.2.4
 
   tests/vite:
-    dependencies:
-      '@tbd54566975/web5':
-        specifier: 0.8.0-alpha-20230728-d004f01
-        version: 0.8.0-alpha-20230728-d004f01
     devDependencies:
       crypto-browserify:
         specifier: ^3.12.0
@@ -136,6 +132,9 @@ importers:
       vite:
         specifier: ^4.4.0
         version: 4.4.10
+      vite-plugin-commonjs:
+        specifier: ^0.10.0
+        version: 0.10.0
       vite-plugin-node-stdlib-browser:
         specifier: ^0.2.1
         version: 0.2.1(node-stdlib-browser@1.2.0)(vite@4.4.10)
@@ -1727,21 +1726,6 @@ packages:
       uri-js: 4.4.1
     dev: false
 
-  /@decentralized-identity/ion-tools@1.1.1:
-    resolution: {integrity: sha512-+A7wJxALp/XoX5eBMFuZjeAK/59dXy6nMfkmlm8cldcGg9XYm+xH+Zq0jVL28dTP9kw11ujNVruyrQGejI2dAA==}
-    engines: {node: '>= 18'}
-    dependencies:
-      '@decentralized-identity/ion-pow-sdk': 1.0.17
-      '@decentralized-identity/ion-sdk': 1.0.1
-      '@noble/ed25519': 2.0.0
-      '@noble/secp256k1': 2.0.0
-      chai: 4.3.10
-      cross-fetch: 3.1.8
-      multiformats: 12.1.2
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
@@ -3207,10 +3191,6 @@ packages:
     dev: false
     optional: true
 
-  /@noble/ciphers@0.1.3:
-    resolution: {integrity: sha512-L75KBG/jf6YNxSvV0w0tsC8OIOsLh9sk6mqLUNZ+3/UhDBrAHQAvTTspwMoBlB84ymupIhq+E9QOhr6H1g/xog==}
-    dev: false
-
   /@noble/ciphers@0.1.4:
     resolution: {integrity: sha512-d3ZR8vGSpy3v/nllS+bD/OMN5UZqusWiQqkyj7AwzTnhXFH72pF5oB4Ach6DQ50g5kXxC28LdaYBEpsyv9KOUQ==}
     dev: false
@@ -3240,12 +3220,10 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-    dev: false
 
   /@nodelib/fs.stat@2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
-    dev: false
 
   /@nodelib/fs.walk@1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
@@ -3253,7 +3231,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
-    dev: false
 
   /@polka/url@1.0.0-next.23:
     resolution: {integrity: sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==}
@@ -3529,72 +3506,6 @@ packages:
       defer-to-connect: 1.1.3
     dev: false
 
-  /@tbd54566975/common@0.8.0-alpha-20230728-d004f01:
-    resolution: {integrity: sha512-6rB22uJbDdQ0Qjp7YHTEyNfzTQYfg6oVp+cNSCEOOoeb9HAgixBHyXK82HUOLMb+MLB8EeYq5hrTsVMEN70zJw==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      multiformats: 11.0.2
-    dev: false
-
-  /@tbd54566975/crypto@0.8.0-alpha-20230728-d004f01:
-    resolution: {integrity: sha512-LmUkvVOIqqYKNnZJMyyEP4YwG18RRyOH/qFwZvOuwyFGJQClixYSZz1aHG0mBsQlOzid5o06hrLNlEr42568Rw==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@noble/ciphers': 0.1.3
-      '@noble/curves': 1.1.0
-      '@noble/hashes': 1.3.1
-      '@tbd54566975/common': 0.8.0-alpha-20230728-d004f01
-      ed2curve: 0.3.0
-    dev: false
-
-  /@tbd54566975/dids@0.8.0-alpha-20230728-d004f01:
-    resolution: {integrity: sha512-EQCGxW3MM6dm7UpfogrtDuMCRBblX0D/fLC6qASZZceU2dYpZigo6HmIZoNmwZjXyk3c4ppBeqMjcmfkSQc6sQ==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@decentralized-identity/ion-tools': 1.1.1
-      '@tbd54566975/common': 0.8.0-alpha-20230728-d004f01
-      '@tbd54566975/crypto': 0.8.0-alpha-20230728-d004f01
-      '@tbd54566975/dwn-sdk-js': 0.1.0-unstable-2023-07-18-09-24-a78a613
-      cross-fetch: 4.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@tbd54566975/dwn-sdk-js@0.1.0-unstable-2023-07-18-09-24-a78a613:
-    resolution: {integrity: sha512-bHWRQDaBX9yA8+NtfbTGsUx3FZJDHuSf5tiaB/If7av38M3xTG6BUXXRmAzrwwafU4iOHUoTSNca9ykyEwtt3g==}
-    engines: {node: '>= 18'}
-    dependencies:
-      '@ipld/dag-cbor': 9.0.3
-      '@js-temporal/polyfill': 0.4.4
-      '@noble/ed25519': 2.0.0
-      '@noble/secp256k1': 2.0.0
-      abstract-level: 1.0.3
-      ajv: 8.12.0
-      blockstore-core: 4.2.0
-      cross-fetch: 3.1.6
-      eciesjs: 0.4.0
-      flat: 5.0.2
-      interface-blockstore: 5.2.3
-      interface-store: 5.1.2
-      ipfs-unixfs-exporter: 13.1.5
-      ipfs-unixfs-importer: 15.1.5
-      level: 8.0.0
-      lodash: 4.17.21
-      lru-cache: 9.1.2
-      ms: 2.1.3
-      multiformats: 11.0.2
-      randombytes: 2.1.0
-      readable-stream: 4.4.0
-      secp256k1: 5.0.0
-      ulid: 2.3.0
-      uuid: 8.3.2
-      varint: 6.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
   /@tbd54566975/dwn-sdk-js@0.2.1:
     resolution: {integrity: sha512-7rFi0zvpt0F/6E2Pow5+iCnf35YGIUneI9U4J43A8NfP0Gh5S2eJkApvhrPOyt50Xq2MerFR9F5E3BE2E0jJRQ==}
     engines: {node: '>= 18'}
@@ -3656,65 +3567,6 @@ packages:
       ulidx: 2.1.0
       uuid: 8.3.2
       varint: 6.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@tbd54566975/web5-agent@0.8.0-alpha-20230728-d004f01:
-    resolution: {integrity: sha512-Lpcz1/d6k0kBsYJUYLo4t0N3xeu33S/biAwiHShQJFpW28e40bMkV7pkR3c1E8laHDj3zIx+Ra4ifOG8Pp8ESA==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@tbd54566975/dwn-sdk-js': 0.1.0-unstable-2023-07-18-09-24-a78a613
-      readable-stream: 4.4.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@tbd54566975/web5-proxy-agent@0.8.0-alpha-20230728-d004f01:
-    resolution: {integrity: sha512-LfvwMH45cis4UHfDw61qwbagfBNVVUk3SKFRy75qoahOyOKUu/UWDiuDE/kXZQEkku8DUFfaal5wMBP/Hh6Jxg==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@tbd54566975/web5-agent': 0.8.0-alpha-20230728-d004f01
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@tbd54566975/web5-user-agent@0.8.0-alpha-20230728-d004f01:
-    resolution: {integrity: sha512-RWT2WGO3rTW8n77GoH+vetPY+520Bu7U3x+a3AXDC/DipwgFlzoqDeePvMfoibuQFugpeenzGp0Q7z3b4GnVuQ==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@decentralized-identity/ion-tools': 1.1.1
-      '@tbd54566975/dids': 0.8.0-alpha-20230728-d004f01
-      '@tbd54566975/dwn-sdk-js': 0.1.0-unstable-2023-07-18-09-24-a78a613
-      '@tbd54566975/web5-agent': 0.8.0-alpha-20230728-d004f01
-      abstract-level: 1.0.3
-      cross-fetch: 4.0.0
-      flat: 5.0.2
-      level: 8.0.0
-      readable-web-to-node-stream: 3.0.2
-      uuid: 9.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@tbd54566975/web5@0.8.0-alpha-20230728-d004f01:
-    resolution: {integrity: sha512-R9Dob0cSBR/V8T4z1BfxOhBlAV3cEqvptkI5twfNskJuKk56KYtYRmbu8qEgrf4lT2PidbwuqiqmnkdTBMmm9g==}
-    engines: {node: '>=18.0.0'}
-    dependencies:
-      '@decentralized-identity/ion-tools': 1.1.1
-      '@tbd54566975/crypto': 0.8.0-alpha-20230728-d004f01
-      '@tbd54566975/dids': 0.8.0-alpha-20230728-d004f01
-      '@tbd54566975/dwn-sdk-js': 0.1.0-unstable-2023-07-18-09-24-a78a613
-      '@tbd54566975/web5-agent': 0.8.0-alpha-20230728-d004f01
-      '@tbd54566975/web5-proxy-agent': 0.8.0-alpha-20230728-d004f01
-      '@tbd54566975/web5-user-agent': 0.8.0-alpha-20230728-d004f01
-      level: 8.0.0
-      ms: 2.1.3
-      readable-web-to-node-stream: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -4550,10 +4402,6 @@ packages:
       util: 0.12.5
     dev: true
 
-  /assertion-error@1.1.0:
-    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
-    dev: false
-
   /ast-types-flow@0.0.7:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
     dev: false
@@ -5002,19 +4850,6 @@ packages:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
     dev: false
 
-  /chai@4.3.10:
-    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
-    engines: {node: '>=4'}
-    dependencies:
-      assertion-error: 1.1.0
-      check-error: 1.0.3
-      deep-eql: 4.1.3
-      get-func-name: 2.0.2
-      loupe: 2.3.6
-      pathval: 1.1.1
-      type-detect: 4.0.8
-    dev: false
-
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -5041,12 +4876,6 @@ packages:
 
   /character-reference-invalid@1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
-    dev: false
-
-  /check-error@1.0.3:
-    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
-    dependencies:
-      get-func-name: 2.0.2
     dev: false
 
   /cheerio-select@2.1.0:
@@ -5436,14 +5265,6 @@ packages:
       - encoding
     dev: false
 
-  /cross-fetch@3.1.6:
-    resolution: {integrity: sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==}
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /cross-fetch@3.1.8:
     resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
     dependencies:
@@ -5714,13 +5535,6 @@ packages:
       mimic-response: 1.0.1
     dev: false
 
-  /deep-eql@4.1.3:
-    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
-    engines: {node: '>=6'}
-    dependencies:
-      type-detect: 4.0.8
-    dev: false
-
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -5964,12 +5778,6 @@ packages:
     resolution: {integrity: sha512-z4dEeaH16xxYVgtxJ8YVwpifH4Keg4gyp5F451mnDNwbAN3MgL5jcoEQGpqJrapv/zW8KwDnXG21Dw5B0hqvmw==}
     dependencies:
       '@noble/curves': 1.1.0
-    dev: false
-
-  /ed2curve@0.3.0:
-    resolution: {integrity: sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==}
-    dependencies:
-      tweetnacl: 1.0.3
     dev: false
 
   /ee-first@1.1.1:
@@ -6624,7 +6432,6 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
-    dev: false
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -6647,7 +6454,6 @@ packages:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
     dependencies:
       reusify: 1.0.4
-    dev: false
 
   /faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
@@ -6900,10 +6706,6 @@ packages:
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-    dev: false
-
-  /get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
     dev: false
 
   /get-intrinsic@1.2.1:
@@ -8351,12 +8153,6 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
-  /loupe@2.3.6:
-    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
-    dependencies:
-      get-func-name: 2.0.2
-    dev: false
-
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
@@ -8393,6 +8189,13 @@ packages:
 
   /magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -8472,7 +8275,6 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-    dev: false
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -8685,10 +8487,6 @@ packages:
     dependencies:
       lower-case: 2.0.2
       tslib: 2.6.2
-    dev: false
-
-  /node-addon-api@5.1.0:
-    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
     dev: false
 
   /node-emoji@1.11.0:
@@ -9130,10 +8928,6 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: false
-
-  /pathval@1.1.1:
-    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: false
 
   /pbkdf2@3.1.2:
@@ -9757,7 +9551,6 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-    dev: false
 
   /queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
@@ -10307,7 +10100,6 @@ packages:
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-    dev: false
 
   /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -10353,7 +10145,6 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
-    dev: false
 
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
@@ -10441,16 +10232,6 @@ packages:
 
   /search-insights@2.8.3:
     resolution: {integrity: sha512-W9rZfQ9XEfF0O6ntgQOTI7Txc8nkZrO4eJ/pTHK0Br6wWND2sPGPoWg+yGhdIW7wMbLqk8dc23IyEtLlNGpeNw==}
-    dev: false
-
-  /secp256k1@5.0.0:
-    resolution: {integrity: sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==}
-    engines: {node: '>=14.0.0'}
-    requiresBuild: true
-    dependencies:
-      elliptic: 6.5.4
-      node-addon-api: 5.1.0
-      node-gyp-build: 4.6.1
     dev: false
 
   /section-matter@1.0.0:
@@ -11097,20 +10878,11 @@ packages:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
     dev: true
 
-  /tweetnacl@1.0.3:
-    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
-    dev: false
-
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
-    dev: false
-
-  /type-detect@4.0.8:
-    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
-    engines: {node: '>=4'}
     dev: false
 
   /type-fest@0.20.2:
@@ -11490,11 +11262,6 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
-  /uuid@9.0.0:
-    resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
-    hasBin: true
-    dev: false
-
   /value-equal@1.0.1:
     resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
     dev: false
@@ -11530,6 +11297,24 @@ packages:
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
     dev: false
+
+  /vite-plugin-commonjs@0.10.0:
+    resolution: {integrity: sha512-tl0/fy4VJ9yMjL4QocviiDan1iyKvUIY7Pn+pn6rpWyyqdprzgP4s2UFXoMiJIVYMV6oJ5goyAHZMKJkS/CxPA==}
+    dependencies:
+      acorn: 8.10.0
+      fast-glob: 3.3.1
+      magic-string: 0.30.5
+      vite-plugin-dynamic-import: 1.5.0
+    dev: true
+
+  /vite-plugin-dynamic-import@1.5.0:
+    resolution: {integrity: sha512-Qp85c+AVJmLa8MLni74U4BDiWpUeFNx7NJqbGZyR2XJOU7mgW0cb7nwlAMucFyM4arEd92Nfxp4j44xPi6Fu7g==}
+    dependencies:
+      acorn: 8.10.0
+      es-module-lexer: 1.3.1
+      fast-glob: 3.3.1
+      magic-string: 0.30.5
+    dev: true
 
   /vite-plugin-node-stdlib-browser@0.2.1(node-stdlib-browser@1.2.0)(vite@4.4.10):
     resolution: {integrity: sha512-6u2i613Dkqj5KaTNIrnZvE6y3/awWAp0S5TjucTvGxdhetftB1Mgvblc+nwYzlw6sntPlac8UOC7ttXNh+LZKA==}

--- a/tests/util/web5-test.js
+++ b/tests/util/web5-test.js
@@ -3,38 +3,38 @@ function checkResult(result) {
   const errors = [];
 
   if (!result.didUpdate) {
-    errors.push("Record did not update!");
+    errors.push('Record did not update!');
   }
 
   if (!result.didDelete) {
-    errors.push("Record did not delete!");
+    errors.push('Record did not delete!');
   }
 
   if (result.readStatus.code !== 200) {
-    errors.push("Read status code is not 200!");
+    errors.push('Read status code is not 200!');
   }
 
   if (!result.did) {
-    errors.push("DID is not defined!");
+    errors.push('DID is not defined!');
   }
 
   if (!result.record) {
-    errors.push("Record is not defined!");
+    errors.push('Record is not defined!');
   }
 
   if (!result.web5) {
-    errors.push("Web5 is not defined!");
+    errors.push('Web5 is not defined!');
   }
 
   if (result.updateStatus.code !== 202) {
-    errors.push("Update status is not defined!");
+    errors.push('Update status is not defined!');
   }
 
   if (errors.length > 0) {
     console.error({ errors });
-    throw new Error("One or more checks failed!");
+    throw new Error('One or more checks failed!');
   } else {
-    console.info("All Checks Passed! ✅");
+    console.info('All Checks Passed! ✅');
   }
 }
 
@@ -53,23 +53,23 @@ const checkWeb5 = async (Web5) => {
   try {
     const web5 = await Web5.connect({
       techPreview: {
-        dwnEndpoints: ["http://localhost:3000"],
+        dwnEndpoints: ['http://localhost:3000'],
       },
     });
 
     result.web5 = web5.web5;
     result.did = result.web5.did;
   } catch (error) {
-    console.error("Web5.connect Error:", error);
+    console.error('Web5.connect Error:', error);
   }
 
   try {
     const { record: _record } = await result.web5.dwn.records.write({
-      data: "Hello!",
+      data: 'Hello!',
     });
     result.record = _record;
   } catch (error) {
-    console.error("Create Record Error:", error);
+    console.error('Create Record Error:', error);
   }
 
   try {
@@ -79,16 +79,16 @@ const checkWeb5 = async (Web5) => {
 
     result.readStatus = status;
   } catch (error) {
-    console.error("Read Record Error:", error);
+    console.error('Read Record Error:', error);
   }
 
   try {
-    const { status } = await result.record.update({ data: "Updated!" });
+    const { status } = await result.record.update({ data: 'Updated!' });
     result.updateStatus = status;
 
-    result.didUpdate = (await result.record.data.text()) === "Updated!";
+    result.didUpdate = (await result.record.data.text()) === 'Updated!';
   } catch (error) {
-    console.error("Update Record Error:", error);
+    console.error('Update Record Error:', error);
   }
 
   try {
@@ -96,7 +96,7 @@ const checkWeb5 = async (Web5) => {
     result.deleteStatus = status.code;
     result.didDelete = result.record.isDeleted;
   } catch (error) {
-    console.error("Delete Record Error:", error);
+    console.error('Delete Record Error:', error);
   }
 
   checkResult(result);

--- a/tests/util/web5-test.js
+++ b/tests/util/web5-test.js
@@ -3,38 +3,38 @@ function checkResult(result) {
   const errors = [];
 
   if (!result.didUpdate) {
-    errors.push('Record did not update!');
+    errors.push("Record did not update!");
   }
 
   if (!result.didDelete) {
-    errors.push('Record did not delete!');
+    errors.push("Record did not delete!");
   }
 
   if (result.readStatus.code !== 200) {
-    errors.push('Read status code is not 200!');
+    errors.push("Read status code is not 200!");
   }
 
   if (!result.did) {
-    errors.push('DID is not defined!');
+    errors.push("DID is not defined!");
   }
 
   if (!result.record) {
-    errors.push('Record is not defined!');
+    errors.push("Record is not defined!");
   }
 
   if (!result.web5) {
-    errors.push('Web5 is not defined!');
+    errors.push("Web5 is not defined!");
   }
 
   if (result.updateStatus.code !== 202) {
-    errors.push('Update status is not defined!');
+    errors.push("Update status is not defined!");
   }
 
   if (errors.length > 0) {
     console.error({ errors });
-    throw new Error('One or more checks failed!');
+    throw new Error("One or more checks failed!");
   } else {
-    console.info('All Checks Passed! ✅');
+    console.info("All Checks Passed! ✅");
   }
 }
 
@@ -53,23 +53,23 @@ const checkWeb5 = async (Web5) => {
   try {
     const web5 = await Web5.connect({
       techPreview: {
-        dwnEndpoints: ['http://localhost:3000'],
+        dwnEndpoints: ["http://localhost:3000"],
       },
     });
 
     result.web5 = web5.web5;
     result.did = result.web5.did;
   } catch (error) {
-    console.error('Web5.connect Error:', error);
+    console.error("Web5.connect Error:", error);
   }
 
   try {
     const { record: _record } = await result.web5.dwn.records.write({
-      data: 'Hello!',
+      data: "Hello!",
     });
     result.record = _record;
   } catch (error) {
-    console.error('Create Record Error:', error);
+    console.error("Create Record Error:", error);
   }
 
   try {
@@ -79,16 +79,16 @@ const checkWeb5 = async (Web5) => {
 
     result.readStatus = status;
   } catch (error) {
-    console.error('Read Record Error:', error);
+    console.error("Read Record Error:", error);
   }
 
   try {
-    const { status } = await result.record.update({ data: 'Updated!' });
+    const { status } = await result.record.update({ data: "Updated!" });
     result.updateStatus = status;
 
-    result.didUpdate = (await result.record.data.text()) === 'Updated!';
+    result.didUpdate = (await result.record.data.text()) === "Updated!";
   } catch (error) {
-    console.error('Update Record Error:', error);
+    console.error("Update Record Error:", error);
   }
 
   try {
@@ -96,7 +96,7 @@ const checkWeb5 = async (Web5) => {
     result.deleteStatus = status.code;
     result.didDelete = result.record.isDeleted;
   } catch (error) {
-    console.error('Delete Record Error:', error);
+    console.error("Delete Record Error:", error);
   }
 
   checkResult(result);

--- a/tests/vite/index.html
+++ b/tests/vite/index.html
@@ -7,7 +7,13 @@
     <title>Vite App</title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app">
+      <h1>Test Results:</h1>
+      <h2>Web5 Results:</h2>
+      <pre id="web5-results"></pre>
+      <h2>Dwn Results:</h2>
+      <pre id="dwn-results"></pre>
+    </div>
     <script type="module" src="/main.js"></script>
   </body>
 </html>

--- a/tests/vite/main.js
+++ b/tests/vite/main.js
@@ -1,6 +1,6 @@
-import { Buffer } from 'buffer';
-import './style.css';
-import { Web5 } from '@web5/api';
+import { Buffer } from "buffer";
+import "./style.css";
+import { Web5 } from "@web5/api";
 import {
   Dwn,
   DataStream,
@@ -12,27 +12,56 @@ import {
   DataStoreLevel,
   EventLogLevel,
   MessageStoreLevel,
-} from '@tbd54566975/dwn-sdk-js';
+} from "@tbd54566975/dwn-sdk-js";
 
-import checkWeb5 from '../util/web5-test.js';
-import checkDwn from '../util/dwn-test.js';
+import checkWeb5 from "../util/web5-test.js";
+import checkDwn from "../util/dwn-test.js";
 
-// import './dwn-sdk-test.js'
-
-if (typeof window !== 'undefined') {
+if (typeof window !== "undefined") {
   window.Buffer = Buffer;
 }
 
-checkWeb5(Web5);
-checkDwn(
-  Dwn,
-  DataStream,
-  DidKeyResolver,
-  Jws,
-  RecordsWrite,
-  RecordsRead,
-  RecordsDelete,
-  MessageStoreLevel,
-  DataStoreLevel,
-  EventLogLevel
-);
+async function displayResults() {
+  const appEl = document.querySelector("#app");
+  if (!appEl) {
+    console.error("Couldn't find #app element");
+    return;
+  }
+
+  try {
+    const web5Results = await checkWeb5(Web5);
+    document.querySelector("#web5-results").innerText = JSON.stringify(
+      web5Results,
+      null,
+      2
+    );
+  } catch (error) {
+    document.querySelector("#web5-results").innerText =
+      "Web5 Test Error: " + error.message;
+  }
+
+  try {
+    const dwnResults = await checkDwn(
+      Dwn,
+      DataStream,
+      DidKeyResolver,
+      Jws,
+      RecordsWrite,
+      RecordsRead,
+      RecordsDelete,
+      MessageStoreLevel,
+      DataStoreLevel,
+      EventLogLevel
+    );
+    document.querySelector("#dwn-results").innerText = JSON.stringify(
+      dwnResults,
+      null,
+      2
+    );
+  } catch (error) {
+    document.querySelector("#dwn-results").innerText =
+      "Dwn Test Error: " + error.message;
+  }
+}
+
+displayResults();

--- a/tests/vite/main.js
+++ b/tests/vite/main.js
@@ -1,27 +1,38 @@
-import './style.css'
-import javascriptLogo from './javascript.svg'
-import viteLogo from '/vite.svg'
-import { setupCounter } from './counter.js'
+import { Buffer } from 'buffer';
+import './style.css';
+import { Web5 } from '@web5/api';
+import {
+  Dwn,
+  DataStream,
+  DidKeyResolver,
+  Jws,
+  RecordsWrite,
+  RecordsRead,
+  RecordsDelete,
+  DataStoreLevel,
+  EventLogLevel,
+  MessageStoreLevel,
+} from '@tbd54566975/dwn-sdk-js';
 
-import './dwn-sdk-test.js'
-import './web5-test.js'
+import checkWeb5 from '../util/web5-test.js';
+import checkDwn from '../util/dwn-test.js';
 
-document.querySelector('#app').innerHTML = `
-  <div>
-    <a href="https://vitejs.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank">
-      <img src="${javascriptLogo}" class="logo vanilla" alt="JavaScript logo" />
-    </a>
-    <h1>Hello Vite!</h1>
-    <div class="card">
-      <button id="counter" type="button"></button>
-    </div>
-    <p class="read-the-docs">
-      Click on the Vite logo to learn more
-    </p>
-  </div>
-`
+// import './dwn-sdk-test.js'
 
-setupCounter(document.querySelector('#counter'))
+if (typeof window !== 'undefined') {
+  window.Buffer = Buffer;
+}
+
+checkWeb5(Web5);
+checkDwn(
+  Dwn,
+  DataStream,
+  DidKeyResolver,
+  Jws,
+  RecordsWrite,
+  RecordsRead,
+  RecordsDelete,
+  MessageStoreLevel,
+  DataStoreLevel,
+  EventLogLevel
+);

--- a/tests/vite/package.json
+++ b/tests/vite/package.json
@@ -8,15 +8,13 @@
     "build": "vite build",
     "preview": "vite preview"
   },
-  "dependencies": {
-    "@tbd54566975/web5": "0.8.0-alpha-20230728-d004f01"
-  },
   "devDependencies": {
     "crypto-browserify": "^3.12.0",
     "node-stdlib-browser": "^1.2.0",
     "process": "0.11.10",
     "stream-browserify": "^3.0.0",
     "vite": "^4.4.0",
+    "vite-plugin-commonjs": "^0.10.0",
     "vite-plugin-node-stdlib-browser": "^0.2.1"
   }
 }

--- a/tests/vite/vite.config.js
+++ b/tests/vite/vite.config.js
@@ -1,13 +1,13 @@
-import { defineConfig } from 'vite'
-import nodePolyfills from 'vite-plugin-node-stdlib-browser'
+import nodePolyfills from 'vite-plugin-node-stdlib-browser';
+import CommonJs from 'vite-plugin-commonjs';
 
 /** @type {import('vite').UserConfig} */
 export default {
   build: {
-    target: ['chrome109', 'edge112', 'firefox102', 'safari15.6', 'ios15.6']
+    target: ['chrome109', 'edge112', 'firefox102', 'safari15.6', 'ios15.6'],
   },
   define: {
-    global: 'globalThis'
+    global: 'globalThis',
   },
-  plugins: [nodePolyfills()],
-}
+  plugins: [nodePolyfills(), CommonJs()],
+};


### PR DESCRIPTION
This PR introduces the necessary changes to run the `checkWeb5` and `checkDwn` functions in Vite.

- Added Buffer Polyfill to main.js
- Added common-js plugin so we can import the test functions