### PR TITLE
`@web5/api` Release v0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.4",
-    "@web5/api": "0.8.3"
+    "@web5/api": "0.8.4-rc.0"
   },
   "scripts": {
     "test:web5": "pnpm -r --workspace-concurrency 1 --no-bail test:web5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.4",
-    "@web5/api": "0.8.4-rc.0"
+    "@web5/api": "0.8.4"
   },
   "scripts": {
     "test:web5": "pnpm -r --workspace-concurrency 1 --no-bail test:web5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@web5/api':
-        specifier: 0.8.4-rc.0
-        version: 0.8.4-rc.0
+        specifier: 0.8.4
+        version: 0.8.4
     devDependencies:
       playwright:
         specifier: ^1.39.0
@@ -3759,8 +3759,8 @@ packages:
       - supports-color
     dev: false
 
-  /@web5/api@0.8.4-rc.0:
-    resolution: {integrity: sha512-sdBTZ5FrRtU2MN0BdV65jrPl7aXTIYmCpS2k/IHQxgNZUQ7SHZm38MfRV4OSZNPJiintUifG4WkJzUcdUO/7BQ==}
+  /@web5/api@0.8.4:
+    resolution: {integrity: sha512-3kqh7KQeeffsOBi+K5Vhpa59+ZgdI1em16drrRd7h59Jj4m8a09Enhw7WjWNLre7rTG84hQqB9+rpS1VHnOaKQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@tbd54566975/dwn-sdk-js': 0.2.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@web5/api':
-        specifier: 0.8.3
-        version: 0.8.3
+        specifier: 0.8.4-rc.0
+        version: 0.8.4-rc.0
     devDependencies:
       playwright:
         specifier: ^1.39.0
@@ -3333,6 +3333,38 @@ packages:
       defer-to-connect: 1.1.3
     dev: false
 
+  /@tbd54566975/dwn-sdk-js@0.2.10:
+    resolution: {integrity: sha512-CoKO8+NciwWNzD4xRoAAgeElqQCXKM4Fc+zEHsUWD0M3E9v67hRWiTHI6AenUfQv1RSEB2H4GHUeUOHuEV72uw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@ipld/dag-cbor': 9.0.3
+      '@js-temporal/polyfill': 0.4.4
+      '@noble/ed25519': 2.0.0
+      '@noble/secp256k1': 2.0.0
+      abstract-level: 1.0.3
+      ajv: 8.12.0
+      blockstore-core: 4.2.0
+      cross-fetch: 4.0.0
+      eciesjs: 0.4.5
+      interface-blockstore: 5.2.3
+      interface-store: 5.1.2
+      ipfs-unixfs-exporter: 13.1.5
+      ipfs-unixfs-importer: 15.1.5
+      level: 8.0.0
+      lodash: 4.17.21
+      lru-cache: 9.1.2
+      ms: 2.1.3
+      multiformats: 11.0.2
+      randombytes: 2.1.0
+      readable-stream: 4.4.2
+      ulidx: 2.1.0
+      uuid: 8.3.2
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
   /@tbd54566975/dwn-sdk-js@0.2.4:
     resolution: {integrity: sha512-d2/8o0sA+kNqyyFovReyviczABPyi5wPNuaS7oPojrmMDN2GC+okifF/rqr4qO393Dk/m07ngk8eXnPPk/oiMQ==}
     engines: {node: '>= 18'}
@@ -3727,15 +3759,15 @@ packages:
       - supports-color
     dev: false
 
-  /@web5/api@0.8.3:
-    resolution: {integrity: sha512-YXQ++ZShtd5LeFRqEMGlhVqJ7Zg5P6bMequpaLl068bCGjtjCwiFFgDtM1KeL36IAzQ4pFLFyj9aTGZ/JgCXHA==}
+  /@web5/api@0.8.4-rc.0:
+    resolution: {integrity: sha512-sdBTZ5FrRtU2MN0BdV65jrPl7aXTIYmCpS2k/IHQxgNZUQ7SHZm38MfRV4OSZNPJiintUifG4WkJzUcdUO/7BQ==}
     engines: {node: '>=18.0.0'}
     dependencies:
-      '@tbd54566975/dwn-sdk-js': 0.2.8
+      '@tbd54566975/dwn-sdk-js': 0.2.10
       '@web5/agent': 0.2.5
       '@web5/common': 0.2.2
       '@web5/crypto': 0.2.2
-      '@web5/dids': 0.2.3
+      '@web5/dids': 0.2.4
       '@web5/user-agent': 0.2.5
       level: 8.0.0
       ms: 2.1.3
@@ -3775,6 +3807,25 @@ packages:
 
   /@web5/dids@0.2.3:
     resolution: {integrity: sha512-Y3PHOavNkSyjBxZQEpKE6XueaqemBO5w0UMOnFh4xH6+5B43ENEE4LHIqVyn2bCpfEBGLXENgDZYqyJphBu0pA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@decentralized-identity/ion-pow-sdk': 1.0.17
+      '@decentralized-identity/ion-sdk': 1.0.1
+      '@web5/common': 0.2.2
+      '@web5/crypto': 0.2.2
+      did-resolver: 4.1.0
+      dns-packet: 5.6.1
+      level: 8.0.0
+      ms: 2.1.3
+      pkarr: 1.1.1
+      z32: 1.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@web5/dids@0.2.4:
+    resolution: {integrity: sha512-e+m+xgpiM8ydTJgWcPdwmjILLMZYdl2kwahlO22mK0azSKVrg1klpGrUODzqkrWrQ5O0tnOyqEy39FcD5Sy11w==}
     engines: {node: '>=18.0.0'}
     dependencies:
       '@decentralized-identity/ion-pow-sdk': 1.0.17

--- a/tests/electron-vite/.yarnrc.yml
+++ b/tests/electron-vite/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/tests/electron-vite/package.json
+++ b/tests/electron-vite/package.json
@@ -24,7 +24,7 @@
     "@electron-toolkit/preload": "^2.0.0",
     "@electron-toolkit/utils": "^2.0.0",
     "@tbd54566975/dwn-sdk-js": "0.2.4",
-    "@web5/api": "0.8.3"
+    "@web5/api": "0.8.4-rc.0"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^1.0.1",

--- a/tests/electron-vite/package.json
+++ b/tests/electron-vite/package.json
@@ -24,7 +24,7 @@
     "@electron-toolkit/preload": "^2.0.0",
     "@electron-toolkit/utils": "^2.0.0",
     "@tbd54566975/dwn-sdk-js": "0.2.4",
-    "@web5/api": "0.8.4-rc.0"
+    "@web5/api": "0.8.4"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^1.0.1",

--- a/tests/electron-vite/yarn.lock
+++ b/tests/electron-vite/yarn.lock
@@ -707,6 +707,35 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@tbd54566975/dwn-sdk-js@0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.10.tgz#64c8c845094fb132dd393294109a38fbee4b381d"
+  integrity sha512-CoKO8+NciwWNzD4xRoAAgeElqQCXKM4Fc+zEHsUWD0M3E9v67hRWiTHI6AenUfQv1RSEB2H4GHUeUOHuEV72uw==
+  dependencies:
+    "@ipld/dag-cbor" "9.0.3"
+    "@js-temporal/polyfill" "0.4.4"
+    "@noble/ed25519" "2.0.0"
+    "@noble/secp256k1" "2.0.0"
+    abstract-level "1.0.3"
+    ajv "8.12.0"
+    blockstore-core "4.2.0"
+    cross-fetch "4.0.0"
+    eciesjs "0.4.5"
+    interface-blockstore "5.2.3"
+    interface-store "5.1.2"
+    ipfs-unixfs-exporter "13.1.5"
+    ipfs-unixfs-importer "15.1.5"
+    level "8.0.0"
+    lodash "4.17.21"
+    lru-cache "9.1.2"
+    ms "2.1.3"
+    multiformats "11.0.2"
+    randombytes "2.1.0"
+    readable-stream "4.4.2"
+    ulidx "2.1.0"
+    uuid "8.3.2"
+    varint "6.0.0"
+
 "@tbd54566975/dwn-sdk-js@0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.4.tgz#8af8f62689f84e9fae470b61bacab8711836c519"
@@ -972,16 +1001,16 @@
     readable-stream "4.4.2"
     readable-web-to-node-stream "3.0.2"
 
-"@web5/api@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.3.tgz#aa7e6a30f37187a7b22ef2d7502643dd883c4935"
-  integrity sha512-YXQ++ZShtd5LeFRqEMGlhVqJ7Zg5P6bMequpaLl068bCGjtjCwiFFgDtM1KeL36IAzQ4pFLFyj9aTGZ/JgCXHA==
+"@web5/api@0.8.4-rc.0":
+  version "0.8.4-rc.0"
+  resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.4-rc.0.tgz#ad3458b4f013baefa9357361136eb50c783ff905"
+  integrity sha512-sdBTZ5FrRtU2MN0BdV65jrPl7aXTIYmCpS2k/IHQxgNZUQ7SHZm38MfRV4OSZNPJiintUifG4WkJzUcdUO/7BQ==
   dependencies:
-    "@tbd54566975/dwn-sdk-js" "0.2.8"
+    "@tbd54566975/dwn-sdk-js" "0.2.10"
     "@web5/agent" "0.2.5"
     "@web5/common" "0.2.2"
     "@web5/crypto" "0.2.2"
-    "@web5/dids" "0.2.3"
+    "@web5/dids" "0.2.4"
     "@web5/user-agent" "0.2.5"
     level "8.0.0"
     ms "2.1.3"
@@ -1019,6 +1048,22 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@web5/dids/-/dids-0.2.3.tgz#20da60a7afd06ac8edd2cd995f55d0489ea89a92"
   integrity sha512-Y3PHOavNkSyjBxZQEpKE6XueaqemBO5w0UMOnFh4xH6+5B43ENEE4LHIqVyn2bCpfEBGLXENgDZYqyJphBu0pA==
+  dependencies:
+    "@decentralized-identity/ion-pow-sdk" "1.0.17"
+    "@decentralized-identity/ion-sdk" "1.0.1"
+    "@web5/common" "0.2.2"
+    "@web5/crypto" "0.2.2"
+    did-resolver "4.1.0"
+    dns-packet "5.6.1"
+    level "8.0.0"
+    ms "2.1.3"
+    pkarr "1.1.1"
+    z32 "1.0.1"
+
+"@web5/dids@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@web5/dids/-/dids-0.2.4.tgz#e4ab4924d7c73c81621b2216d39d9923a03840b5"
+  integrity sha512-e+m+xgpiM8ydTJgWcPdwmjILLMZYdl2kwahlO22mK0azSKVrg1klpGrUODzqkrWrQ5O0tnOyqEy39FcD5Sy11w==
   dependencies:
     "@decentralized-identity/ion-pow-sdk" "1.0.17"
     "@decentralized-identity/ion-sdk" "1.0.1"

--- a/tests/electron-vite/yarn.lock
+++ b/tests/electron-vite/yarn.lock
@@ -1001,10 +1001,10 @@
     readable-stream "4.4.2"
     readable-web-to-node-stream "3.0.2"
 
-"@web5/api@0.8.4-rc.0":
-  version "0.8.4-rc.0"
-  resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.4-rc.0.tgz#ad3458b4f013baefa9357361136eb50c783ff905"
-  integrity sha512-sdBTZ5FrRtU2MN0BdV65jrPl7aXTIYmCpS2k/IHQxgNZUQ7SHZm38MfRV4OSZNPJiintUifG4WkJzUcdUO/7BQ==
+"@web5/api@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.4.tgz#b78ea5b54b44345764db87b64a8f552e68514468"
+  integrity sha512-3kqh7KQeeffsOBi+K5Vhpa59+ZgdI1em16drrRd7h59Jj4m8a09Enhw7WjWNLre7rTG84hQqB9+rpS1VHnOaKQ==
   dependencies:
     "@tbd54566975/dwn-sdk-js" "0.2.10"
     "@web5/agent" "0.2.5"

--- a/tests/reactnative/.yarnrc.yml
+++ b/tests/reactnative/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/tests/reactnative/package.json
+++ b/tests/reactnative/package.json
@@ -15,7 +15,7 @@
     "@tbd54566975/web5-react-native-metro-config": "1.0.0",
     "@tbd54566975/web5-react-native-polyfills": "^0.2.1",
     "@types/react": "18.2.38",
-    "@web5/api": "0.8.4-rc.0",
+    "@web5/api": "0.8.4",
     "@web5/dids": "0.2.3",
     "@web5/identity-agent": "0.2.5",
     "expo": "49.0.20",

--- a/tests/reactnative/package.json
+++ b/tests/reactnative/package.json
@@ -15,7 +15,7 @@
     "@tbd54566975/web5-react-native-metro-config": "1.0.0",
     "@tbd54566975/web5-react-native-polyfills": "^0.2.1",
     "@types/react": "18.2.38",
-    "@web5/api": "0.8.3",
+    "@web5/api": "0.8.4-rc.0",
     "@web5/dids": "0.2.3",
     "@web5/identity-agent": "0.2.5",
     "expo": "49.0.20",

--- a/tests/reactnative/yarn.lock
+++ b/tests/reactnative/yarn.lock
@@ -2581,10 +2581,10 @@
     readable-stream "4.4.2"
     readable-web-to-node-stream "3.0.2"
 
-"@web5/api@0.8.4-rc.0":
-  version "0.8.4-rc.0"
-  resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.4-rc.0.tgz#ad3458b4f013baefa9357361136eb50c783ff905"
-  integrity sha512-sdBTZ5FrRtU2MN0BdV65jrPl7aXTIYmCpS2k/IHQxgNZUQ7SHZm38MfRV4OSZNPJiintUifG4WkJzUcdUO/7BQ==
+"@web5/api@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.4.tgz#b78ea5b54b44345764db87b64a8f552e68514468"
+  integrity sha512-3kqh7KQeeffsOBi+K5Vhpa59+ZgdI1em16drrRd7h59Jj4m8a09Enhw7WjWNLre7rTG84hQqB9+rpS1VHnOaKQ==
   dependencies:
     "@tbd54566975/dwn-sdk-js" "0.2.10"
     "@web5/agent" "0.2.5"

--- a/tests/reactnative/yarn.lock
+++ b/tests/reactnative/yarn.lock
@@ -2346,6 +2346,35 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@tbd54566975/dwn-sdk-js@0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.10.tgz#64c8c845094fb132dd393294109a38fbee4b381d"
+  integrity sha512-CoKO8+NciwWNzD4xRoAAgeElqQCXKM4Fc+zEHsUWD0M3E9v67hRWiTHI6AenUfQv1RSEB2H4GHUeUOHuEV72uw==
+  dependencies:
+    "@ipld/dag-cbor" "9.0.3"
+    "@js-temporal/polyfill" "0.4.4"
+    "@noble/ed25519" "2.0.0"
+    "@noble/secp256k1" "2.0.0"
+    abstract-level "1.0.3"
+    ajv "8.12.0"
+    blockstore-core "4.2.0"
+    cross-fetch "4.0.0"
+    eciesjs "0.4.5"
+    interface-blockstore "5.2.3"
+    interface-store "5.1.2"
+    ipfs-unixfs-exporter "13.1.5"
+    ipfs-unixfs-importer "15.1.5"
+    level "8.0.0"
+    lodash "4.17.21"
+    lru-cache "9.1.2"
+    ms "2.1.3"
+    multiformats "11.0.2"
+    randombytes "2.1.0"
+    readable-stream "4.4.2"
+    ulidx "2.1.0"
+    uuid "8.3.2"
+    varint "6.0.0"
+
 "@tbd54566975/dwn-sdk-js@0.2.8":
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.8.tgz#56775b9b8d6e54fb8626af5c53837c05af5b2a53"
@@ -2552,16 +2581,16 @@
     readable-stream "4.4.2"
     readable-web-to-node-stream "3.0.2"
 
-"@web5/api@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.3.tgz#aa7e6a30f37187a7b22ef2d7502643dd883c4935"
-  integrity sha512-YXQ++ZShtd5LeFRqEMGlhVqJ7Zg5P6bMequpaLl068bCGjtjCwiFFgDtM1KeL36IAzQ4pFLFyj9aTGZ/JgCXHA==
+"@web5/api@0.8.4-rc.0":
+  version "0.8.4-rc.0"
+  resolved "https://registry.yarnpkg.com/@web5/api/-/api-0.8.4-rc.0.tgz#ad3458b4f013baefa9357361136eb50c783ff905"
+  integrity sha512-sdBTZ5FrRtU2MN0BdV65jrPl7aXTIYmCpS2k/IHQxgNZUQ7SHZm38MfRV4OSZNPJiintUifG4WkJzUcdUO/7BQ==
   dependencies:
-    "@tbd54566975/dwn-sdk-js" "0.2.8"
+    "@tbd54566975/dwn-sdk-js" "0.2.10"
     "@web5/agent" "0.2.5"
     "@web5/common" "0.2.2"
     "@web5/crypto" "0.2.2"
-    "@web5/dids" "0.2.3"
+    "@web5/dids" "0.2.4"
     "@web5/user-agent" "0.2.5"
     level "8.0.0"
     ms "2.1.3"
@@ -2599,6 +2628,22 @@
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@web5/dids/-/dids-0.2.3.tgz#20da60a7afd06ac8edd2cd995f55d0489ea89a92"
   integrity sha512-Y3PHOavNkSyjBxZQEpKE6XueaqemBO5w0UMOnFh4xH6+5B43ENEE4LHIqVyn2bCpfEBGLXENgDZYqyJphBu0pA==
+  dependencies:
+    "@decentralized-identity/ion-pow-sdk" "1.0.17"
+    "@decentralized-identity/ion-sdk" "1.0.1"
+    "@web5/common" "0.2.2"
+    "@web5/crypto" "0.2.2"
+    did-resolver "4.1.0"
+    dns-packet "5.6.1"
+    level "8.0.0"
+    ms "2.1.3"
+    pkarr "1.1.1"
+    z32 "1.0.1"
+
+"@web5/dids@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@web5/dids/-/dids-0.2.4.tgz#e4ab4924d7c73c81621b2216d39d9923a03840b5"
+  integrity sha512-e+m+xgpiM8ydTJgWcPdwmjILLMZYdl2kwahlO22mK0azSKVrg1klpGrUODzqkrWrQ5O0tnOyqEy39FcD5Sy11w==
   dependencies:
     "@decentralized-identity/ion-pow-sdk" "1.0.17"
     "@decentralized-identity/ion-sdk" "1.0.1"


### PR DESCRIPTION
This PR bumps the `@web5/api` version from `0.8.3` to `0.8.4`.

> [!NOTE]
> Version will initially be bumped to `0.8.4-rc.0` to verify all tests are passing and for Dev Programs to complete other testing/validation.  After all of these steps are complete, the `0.8.4` release will be published to NPM Registry and then a commit will be pushed to this PR to bump to `0.8.4` before approval/merging.